### PR TITLE
made this work with multiplayer workbench

### DIFF
--- a/assets/fonts/FG_Virgil.ttf.import
+++ b/assets/fonts/FG_Virgil.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/FG_Virgil.ttf-e0aa9761b187e97349a33f4699cc053
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/game.gd
+++ b/game.gd
@@ -182,7 +182,7 @@ func restart():
 	current_round = 0
 	cardsinfo_played = [{}, {}, {}]
 	_rounds_won = []
-	get_tree().reload_current_scene()
+	#get_tree().reload_current_scene()
 
 
 @rpc("authority", "call_local", "reliable")

--- a/global_input.gd
+++ b/global_input.gd
@@ -41,4 +41,3 @@ func _process(_delta):
 			get_tree().paused = false
 		await get_tree().process_frame
 		get_tree().paused = true
-

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,11 @@ run/main_scene="res://scenes/main.tscn"
 config/features=PackedStringArray("4.3", "GL Compatibility")
 config/icon="res://icon.svg"
 
+[audio]
+
+general/2d_panning_strength=0.91
+driver/enable_input=true
+
 [autoload]
 
 GlobalInput="*res://global_input.gd"

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="TRUCO!"
 run/main_scene="res://scenes/main.tscn"
-config/features=PackedStringArray("4.2", "GL Compatibility")
+config/features=PackedStringArray("4.3", "GL Compatibility")
 config/icon="res://icon.svg"
 
 [autoload]
@@ -36,7 +36,7 @@ movie_writer/movie_file="/sysroot/home/manuq/godot-projects/truco-card-game/demo
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/DampedOscillator/plugin.cfg", "res://addons/play_centered/plugin.cfg", "res://addons/script-tabs/plugin.cfg", "res://addons/trail_2d/plugin.cfg")
+enabled=PackedStringArray("res://addons/DampedOscillator/plugin.cfg", "res://addons/play_centered/plugin.cfg", "res://addons/script-tabs/plugin.cfg")
 
 [gui]
 
@@ -46,37 +46,37 @@ theme/custom="res://theme.tres"
 
 fullscreen={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"location":0,"echo":false,"script":null)
 ]
 }
 pause-resume={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":80,"key_label":0,"unicode":112,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":80,"key_label":0,"unicode":112,"location":0,"echo":false,"script":null)
 ]
 }
 next-frame={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":78,"key_label":0,"unicode":110,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":78,"key_label":0,"unicode":110,"location":0,"echo":false,"script":null)
 ]
 }
 restart={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":114,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":114,"location":0,"echo":false,"script":null)
 ]
 }
 rotate-table-more={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
 ]
 }
 rotate-table-less={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
 ]
 }
 toggle-debug={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/scenes/board.gd
+++ b/scenes/board.gd
@@ -143,8 +143,9 @@ func _update_winner_label(winner):
 
 
 func _update_restart_button(winner):
-	%RestartButton.disabled = winner == null
-	%RestartButton.visible = winner != null
+	var restartbuttonvisible = (winner != null and multiplayer.is_server())
+	%RestartButton.disabled = not restartbuttonvisible
+	%RestartButton.visible = restartbuttonvisible
 	if %RestartButton.visible:
 		DampedOscillator.animate(%RestartButton, "rotation_degrees", 200.0, 10.0, 15.0, 100.0)
 
@@ -196,4 +197,7 @@ func _on_area_2d_area_exited(area):
 
 
 func _on_restart_button_pressed():
+	Game.restart()
+
+func _on_quit_button_pressed():
 	Game.restart()

--- a/scenes/board.tscn
+++ b/scenes/board.tscn
@@ -101,6 +101,13 @@ theme_override_font_sizes/font_size = 70
 disabled = true
 text = "RESTART"
 
+[node name="QuitButton" type="Button" parent="MarkerCenter"]
+offset_left = 91.0
+offset_top = 572.0
+offset_right = 146.0
+offset_bottom = 618.0
+text = "Quit"
+
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
 [node name="RoundsLabel" type="Label" parent="CanvasLayer"]
@@ -143,3 +150,4 @@ horizontal_alignment = 2
 [connection signal="area_entered" from="Area2D" to="." method="_on_area_2d_area_entered"]
 [connection signal="area_exited" from="Area2D" to="." method="_on_area_2d_area_exited"]
 [connection signal="pressed" from="MarkerCenter/RestartButton" to="." method="_on_restart_button_pressed"]
+[connection signal="pressed" from="MarkerCenter/QuitButton" to="." method="_on_quit_button_pressed"]

--- a/scenes/enter.gd
+++ b/scenes/enter.gd
@@ -1,5 +1,71 @@
 extends Control
 
+@onready var NetworkGateway = get_node("/root/Main").find_child("NetworkGateway")
+@onready var MQTTsignalling = NetworkGateway.MQTTsignalling
+
+var brokeraddress = "mosquitto.doesliverpool.xyz"
+
+var possibleusernames = ["Alice", "Beth", "Cath", "Dan", "Earl", "Fred", "George", "Harry", "Ivan", "John", "Kevin", "Larry", "Martin", "Oliver", "Peter", "Quentin", "Robert", "Samuel", "Thomas", "Ulrik", "Victor", "Wayne", "Xavier", "Youngs", "Zephir"]
+func _ready():
+	randomize()
+	$LineEditName.text = possibleusernames[randi_range(0, len(possibleusernames)-1)]
+	print(NetworkGateway)	
+	NetworkGateway.MQTTsignalling.connect("xclientstatusesupdate", xclientstatusesupdate)
+	NetworkGateway.MQTTsignalling.connect("messagereceived", messagereceived)
+
+
+var playerswaiting = [ ]
+func xclientstatusesupdate():
+	$PlayersInGame.clear()
+	$PlayersWaiting.clear()
+	playerswaiting.clear()
+	for s in MQTTsignalling.xclientstatuses:
+		if MQTTsignalling.xclientstatuses[s] == "closed":
+			continue
+		var playername = s
+		if MQTTsignalling.xclienttreeitems.has(s) and is_instance_valid(MQTTsignalling.xclienttreeitems[s]):
+			playername = MQTTsignalling.xclienttreeitems[s].get_text(1)
+		if MQTTsignalling.xclientstatuses[s] == "unconnected":
+			$PlayersWaiting.add_item(playername)
+			playerswaiting.append(s)
+		else:
+			$PlayersInGame.add_item(playername)
 
 func _on_button_pressed():
-	Multiplayer.host_or_join_game($LineEdit.text)
+	var clientme = MQTTsignalling.get_node("MQTT").client_id
+	var notherplayers = 0
+	for s in playerswaiting:
+		if s != clientme:
+			MQTTsignalling.sendmessage_toclient(s, "<joinme>")
+			notherplayers += 1
+			if notherplayers == 3:
+				break
+	Multiplayer.host_or_join_game(true)
+
+func messagereceived(msg, fromclientid):
+	if msg == "<joinme>":
+		Multiplayer.host_or_join_game(false)
+		
+
+func _on_go_online_toggled(toggled_on):
+	if toggled_on:
+		$LineEditRoom.editable = false
+		$LineEditName.editable = false
+		NetworkGateway.PlayerConnections.LocalPlayer.setplayername($LineEditName.text)
+		NetworkGateway.initialstatemqttwebrtc(NetworkGateway.NETWORK_OPTIONS_MQTT_WEBRTC.AS_NECESSARY_MANUALCHANGE, 
+				$LineEditRoom.text, brokeraddress)
+		$PlayersInGame.visible = true
+		$PlayersWaiting.visible = true
+		$Label3.visible = true
+		$Label4.visible = true
+		$GoOnline.text = "online"
+
+	else:
+		NetworkGateway.selectandtrigger_networkoption(NetworkGateway.NETWORK_OPTIONS_MQTT_WEBRTC.NETWORK_OFF)
+		$LineEditRoom.editable = true
+		$LineEditName.editable = true
+		$PlayersInGame.visible = false
+		$PlayersWaiting.visible = false
+		$Label3.visible = false
+		$Label4.visible = false
+		$GoOnline.text = "go\nonline"

--- a/scenes/enter.gd
+++ b/scenes/enter.gd
@@ -2,4 +2,4 @@ extends Control
 
 
 func _on_button_pressed():
-	Multiplayer.host_or_join_game()
+	Multiplayer.host_or_join_game($LineEdit.text)

--- a/scenes/enter.tscn
+++ b/scenes/enter.tscn
@@ -21,4 +21,23 @@ theme_override_font_sizes/font_size = 40
 text = "enter
 "
 
+[node name="LineEdit" type="LineEdit" parent="."]
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 0.124
+anchor_bottom = 0.104
+offset_left = 294.0
+offset_top = 597.0
+offset_right = 370.04
+offset_bottom = 528.16
+text = "tomato"
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 0
+offset_left = 163.0
+offset_top = 598.0
+offset_right = 261.0
+offset_bottom = 621.0
+text = "Roomname: "
+
 [connection signal="pressed" from="Button" to="." method="_on_button_pressed"]

--- a/scenes/enter.tscn
+++ b/scenes/enter.tscn
@@ -1,6 +1,9 @@
-[gd_scene load_steps=2 format=3 uid="uid://f1e220vwvgj"]
+[gd_scene load_steps=3 format=3 uid="uid://f1e220vwvgj"]
 
 [ext_resource type="Script" path="res://scenes/enter.gd" id="1_bb887"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_eehrf"]
+bg_color = Color(0.193127, 0.355163, 0.195968, 1)
 
 [node name="Enter" type="Control"]
 layout_mode = 3
@@ -13,31 +16,104 @@ script = ExtResource("1_bb887")
 
 [node name="Button" type="Button" parent="."]
 layout_mode = 0
-offset_left = 177.0
-offset_top = 378.0
-offset_right = 351.0
-offset_bottom = 551.0
+offset_left = 178.0
+offset_top = 788.0
+offset_right = 352.0
+offset_bottom = 858.0
 theme_override_font_sizes/font_size = 40
-text = "enter
+text = "start
 "
 
-[node name="LineEdit" type="LineEdit" parent="."]
+[node name="GoOnline" type="Button" parent="."]
+layout_mode = 0
+offset_left = 356.0
+offset_top = 321.0
+offset_right = 505.0
+offset_bottom = 453.0
+theme_override_font_sizes/font_size = 40
+theme_override_styles/pressed = SubResource("StyleBoxFlat_eehrf")
+toggle_mode = true
+text = "go 
+online
+"
+
+[node name="LineEditRoom" type="LineEdit" parent="."]
 layout_mode = 1
 anchors_preset = -1
 anchor_right = 0.124
 anchor_bottom = 0.104
-offset_left = 294.0
-offset_top = 597.0
-offset_right = 370.04
-offset_bottom = 528.16
+offset_left = 184.0
+offset_top = 332.0
+offset_right = 260.04
+offset_bottom = 278.16
 text = "tomato"
 
 [node name="Label" type="Label" parent="."]
 layout_mode = 0
-offset_left = 163.0
-offset_top = 598.0
-offset_right = 261.0
-offset_bottom = 621.0
+offset_left = 53.0
+offset_top = 333.0
+offset_right = 184.0
+offset_bottom = 371.0
 text = "Roomname: "
 
+[node name="LineEditName" type="LineEdit" parent="."]
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 0.124
+anchor_bottom = 0.104
+offset_left = 186.0
+offset_top = 388.0
+offset_right = 262.04
+offset_bottom = 334.16
+text = "person"
+
+[node name="Label2" type="Label" parent="."]
+layout_mode = 0
+offset_left = 49.0
+offset_top = 387.0
+offset_right = 180.0
+offset_bottom = 425.0
+text = "Your name:"
+
+[node name="PlayersInGame" type="ItemList" parent="."]
+visible = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 0.074
+anchor_bottom = 0.042
+offset_left = 278.0
+offset_top = 659.0
+offset_right = 399.04
+offset_bottom = 691.68
+
+[node name="Label3" type="Label" parent="."]
+visible = false
+layout_mode = 0
+offset_left = 74.0
+offset_top = 666.0
+offset_right = 262.0
+offset_bottom = 704.0
+text = "Players in game:"
+
+[node name="PlayersWaiting" type="ItemList" parent="."]
+visible = false
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 0.074
+anchor_bottom = 0.042
+offset_left = 277.0
+offset_top = 491.0
+offset_right = 398.04
+offset_bottom = 592.68
+
+[node name="Label4" type="Label" parent="."]
+visible = false
+layout_mode = 0
+offset_left = 79.0
+offset_top = 488.0
+offset_right = 267.0
+offset_bottom = 526.0
+text = "Players waiting:"
+
 [connection signal="pressed" from="Button" to="." method="_on_button_pressed"]
+[connection signal="toggled" from="GoOnline" to="." method="_on_go_online_toggled"]

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -24,6 +24,8 @@ func _ready():
 	Multiplayer.any_disconnected.connect(_on_game_ended)
 
 	%NetworkGateway.webrtc_multiplayerpeer_set.connect(Multiplayer._on_network_gateway_webrtc_multiplayerpeer_set)
+	%NetworkGateway.set_vox_on()
+
 
 func _on_window_size_changed():
 	%ColorRect.material.set_shader_parameter("resolution", get_tree().get_root().size)

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -12,7 +12,6 @@ var _grid_velocity_for_position = {
 	Game.PlayerPositions.BOTTOM: Vector2(0.0, 0.03),
 }
 
-
 func _ready():
 	get_tree().get_root().size_changed.connect(_on_window_size_changed)
 	%SubViewport.add_child(enter_scene.instantiate())
@@ -22,10 +21,9 @@ func _ready():
 	_on_table_changed()
 	Multiplayer.connected_as_server.connect(_on_connected)
 	Multiplayer.connected_as_client.connect(_on_connected)
+	Multiplayer.any_disconnected.connect(_on_game_ended)
 
-	%NetworkGateway.resolved_as_necessary.connect(Multiplayer._on_network_gateway_resolved_as_necessary)
 	%NetworkGateway.webrtc_multiplayerpeer_set.connect(Multiplayer._on_network_gateway_webrtc_multiplayerpeer_set)
-
 
 func _on_window_size_changed():
 	%ColorRect.material.set_shader_parameter("resolution", get_tree().get_root().size)
@@ -44,12 +42,19 @@ func _on_table_changed():
 
 func _go_to_scene(scene: PackedScene):
 	for c in %SubViewport.get_children():
-		c.queue_free()
-	%SubViewport.add_child(scene.instantiate())
+		if c.name == "Enter":
+			c.visible = (scene == null)
+		else:
+			c.queue_free()
+	if scene:
+		%SubViewport.add_child(scene.instantiate())
 	
 
 func _on_connected():
 	_go_to_scene(player_selection_scene)
+
+func _on_game_ended():
+	_go_to_scene(null)
 
 
 func _on_start_game():

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -23,6 +23,9 @@ func _ready():
 	Multiplayer.connected_as_server.connect(_on_connected)
 	Multiplayer.connected_as_client.connect(_on_connected)
 
+	%NetworkGateway.resolved_as_necessary.connect(Multiplayer._on_network_gateway_resolved_as_necessary)
+	%NetworkGateway.webrtc_multiplayerpeer_set.connect(Multiplayer._on_network_gateway_webrtc_multiplayerpeer_set)
+
 
 func _on_window_size_changed():
 	%ColorRect.material.set_shader_parameter("resolution", get_tree().get_root().size)

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=6 format=3 uid="uid://ckv1ovd054ekp"]
+[gd_scene load_steps=7 format=3 uid="uid://ckv1ovd054ekp"]
 
 [ext_resource type="Script" path="res://scenes/main.gd" id="1_5rl56"]
+[ext_resource type="PackedScene" uid="uid://cfmoahalri06d" path="res://addons/player-networking/NetworkGateway.tscn" id="2_lyohe"]
 
 [sub_resource type="Shader" id="Shader_ifxqe"]
 code = "shader_type canvas_item;
@@ -124,6 +125,14 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+
+[node name="NetworkGateway" parent="MainLayer" instance=ExtResource("2_lyohe")]
+unique_name_in_owner = true
+offset_left = 7.0
+offset_top = 0.0
+offset_right = 645.0
+offset_bottom = 297.0
+scale = Vector2(0.6, 0.6)
 
 [node name="CenterContainer" type="CenterContainer" parent="MainLayer"]
 anchors_preset = 15

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -128,7 +128,6 @@ grow_vertical = 2
 
 [node name="NetworkGateway" parent="MainLayer" instance=ExtResource("2_lyohe")]
 unique_name_in_owner = true
-visible = false
 offset_left = 7.0
 offset_top = 0.0
 offset_right = 645.0

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -128,6 +128,7 @@ grow_vertical = 2
 
 [node name="NetworkGateway" parent="MainLayer" instance=ExtResource("2_lyohe")]
 unique_name_in_owner = true
+visible = false
 offset_left = 7.0
 offset_top = 0.0
 offset_right = 645.0

--- a/scenes/player_selection.tscn
+++ b/scenes/player_selection.tscn
@@ -35,11 +35,11 @@ offset_right = 89.0
 offset_bottom = 270.0
 pivot_offset = Vector2(87, 87)
 theme_override_font_sizes/font_size = 40
-theme_override_styles/normal = SubResource("StyleBoxFlat_t3uv5")
+theme_override_styles/focus = SubResource("StyleBoxFlat_t3uv5")
+theme_override_styles/disabled = SubResource("StyleBoxFlat_t3uv5")
 theme_override_styles/hover = SubResource("StyleBoxFlat_t3uv5")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_t3uv5")
-theme_override_styles/disabled = SubResource("StyleBoxFlat_t3uv5")
-theme_override_styles/focus = SubResource("StyleBoxFlat_t3uv5")
+theme_override_styles/normal = SubResource("StyleBoxFlat_t3uv5")
 text = "bot
 "
 
@@ -51,11 +51,11 @@ offset_right = 236.0
 offset_bottom = 83.0
 pivot_offset = Vector2(87, 87)
 theme_override_font_sizes/font_size = 40
-theme_override_styles/normal = SubResource("StyleBoxFlat_jxugu")
+theme_override_styles/focus = SubResource("StyleBoxFlat_jxugu")
+theme_override_styles/disabled = SubResource("StyleBoxFlat_jxugu")
 theme_override_styles/hover = SubResource("StyleBoxFlat_jxugu")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_jxugu")
-theme_override_styles/disabled = SubResource("StyleBoxFlat_jxugu")
-theme_override_styles/focus = SubResource("StyleBoxFlat_jxugu")
+theme_override_styles/normal = SubResource("StyleBoxFlat_jxugu")
 text = "bot
 "
 
@@ -67,11 +67,11 @@ offset_right = 89.0
 offset_bottom = -104.0
 pivot_offset = Vector2(87, 87)
 theme_override_font_sizes/font_size = 40
-theme_override_styles/normal = SubResource("StyleBoxFlat_t3uv5")
+theme_override_styles/focus = SubResource("StyleBoxFlat_t3uv5")
+theme_override_styles/disabled = SubResource("StyleBoxFlat_t3uv5")
 theme_override_styles/hover = SubResource("StyleBoxFlat_t3uv5")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_t3uv5")
-theme_override_styles/disabled = SubResource("StyleBoxFlat_t3uv5")
-theme_override_styles/focus = SubResource("StyleBoxFlat_t3uv5")
+theme_override_styles/normal = SubResource("StyleBoxFlat_t3uv5")
 text = "bot
 "
 
@@ -83,11 +83,11 @@ offset_right = -59.0
 offset_bottom = 83.0
 pivot_offset = Vector2(87, 87)
 theme_override_font_sizes/font_size = 40
-theme_override_styles/normal = SubResource("StyleBoxFlat_jxugu")
+theme_override_styles/focus = SubResource("StyleBoxFlat_jxugu")
+theme_override_styles/disabled = SubResource("StyleBoxFlat_jxugu")
 theme_override_styles/hover = SubResource("StyleBoxFlat_jxugu")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_jxugu")
-theme_override_styles/disabled = SubResource("StyleBoxFlat_jxugu")
-theme_override_styles/focus = SubResource("StyleBoxFlat_jxugu")
+theme_override_styles/normal = SubResource("StyleBoxFlat_jxugu")
 text = "bot
 "
 


### PR DESCRIPTION
This is a quick hack to show it can potentially work with a minimum of effort.  I won't have time for a few days.

I am creating an addon to manage peer-to-peer WebRTC networking with minimal configuration, and have hacked your project as an exemplar. The addon is copied from [this version](https://github.com/goatchurchprime/godot_multiplayer_networking_workbench/commit/a357e09059c11bd5bd18e9ff291e71331fd35415) of player-networking (also attached as [player-networking.zip](https://github.com/user-attachments/files/16853803/player-networking.zip) -- unzip into `addons/player-networking`)

Further prerequisites to install from the AssetLib:

*    MQTT Client Version: 1.2 installs into addons/mqtt
*    WebRTC plugin - Godot 4.1+ Version: 1.0.6, !!install into addons/webrtc

I currently need to use two signals as callbacks from the system because, unlike ENet, the creation of the `multiplayer.peer_connected` is delayed until some hand-shaking is done.

You can hide the ugly NetworkingWorkbench panel.  It's just there for debug.

The connection type as_necessary means we check if there is a server online first, and then become the server if there isn't, same as the original design.
 
Features to add: 

1) using MQTT to see who is online in what rooms in advance to so you have the option of joining whom you choose to.

2) Voip audio connections between the players.

